### PR TITLE
Make cluster role optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
         default: 5m0s
 runs:
     using: 'docker'
-    image: 'docker://peymanmo/eks-helm-deploy:v2'
+    image: 'ghcr.io/miguelaferreira/eks-helm-deploy:latest'
     env:
         AWS_REGION: ${{ inputs.aws-region }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
         default: 5m0s
 runs:
     using: 'docker'
-    image: 'ghcr.io/miguelaferreira/eks-helm-deploy:latest'
+    image: 'Dockerfile'
     env:
         AWS_REGION: ${{ inputs.aws-region }}
         AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 
 # Login to Kubernetes Cluster.
-aws eks \
+LOGIN_COMMAND="aws eks \
     --region ${AWS_REGION} \
-    update-kubeconfig --name ${CLUSTER_NAME} \
-    --role-arn=${CLUSTER_ROLE_ARN}
+    update-kubeconfig --name ${CLUSTER_NAME}"
+
+if [[ -n "${CLUSTER_ROLE_ARN}" ]]; then
+    LOGIN_COMMAND="${LOGIN_COMMAND} --role-arn=${CLUSTER_ROLE_ARN}"
+fi
+
+${LOGIN_COMMAND}
 
 # Helm Dependency Update
 helm dependency update ${DEPLOY_CHART_PATH:-helm/}


### PR DESCRIPTION
This PR makes the cluster role optional. It also changes the source for the image to have it build on-the-fly. I think that can be changed back to a new image version before merging upstream. 